### PR TITLE
Fix Qt Creator UI parsing error

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,14 +1,181 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
+#include <QCloseEvent>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QStatusBar>
+#include <QTextDocument>
+#include <QTextStream>
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+
+    connect(ui->actionNew, &QAction::triggered, this, &MainWindow::newFile);
+    connect(ui->actionOpen, &QAction::triggered, this, &MainWindow::openFile);
+    connect(ui->actionSave, &QAction::triggered, this, &MainWindow::saveFile);
+    connect(ui->actionSave_As, &QAction::triggered, this, &MainWindow::saveFileAs);
+    connect(ui->actionExit, &QAction::triggered, this, &QWidget::close);
+
+    connect(ui->plainTextEdit->document(), &QTextDocument::modificationChanged,
+            this, &MainWindow::updateWindowTitle);
+
+    connect(ui->actionUndo, &QAction::triggered, ui->plainTextEdit, &QPlainTextEdit::undo);
+    connect(ui->actionRedo, &QAction::triggered, ui->plainTextEdit, &QPlainTextEdit::redo);
+    connect(ui->actionCut, &QAction::triggered, ui->plainTextEdit, &QPlainTextEdit::cut);
+    connect(ui->actionCopy, &QAction::triggered, ui->plainTextEdit, &QPlainTextEdit::copy);
+    connect(ui->actionPaste, &QAction::triggered, ui->plainTextEdit, &QPlainTextEdit::paste);
+
+    connect(ui->plainTextEdit, &QPlainTextEdit::copyAvailable, ui->actionCut, &QAction::setEnabled);
+    connect(ui->plainTextEdit, &QPlainTextEdit::copyAvailable, ui->actionCopy, &QAction::setEnabled);
+    ui->actionCut->setEnabled(false);
+    ui->actionCopy->setEnabled(false);
+
+    newFile();
 }
 
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    if (maybeSave()) {
+        event->accept();
+    } else {
+        event->ignore();
+    }
+}
+
+void MainWindow::newFile()
+{
+    if (!maybeSave()) {
+        return;
+    }
+
+    ui->plainTextEdit->clear();
+    ui->plainTextEdit->document()->setModified(false);
+    m_currentFilePath.clear();
+    updateWindowTitle();
+    statusBar()->showMessage(tr("New document"), 2000);
+}
+
+void MainWindow::openFile()
+{
+    if (!maybeSave()) {
+        return;
+    }
+
+    const QString filePath = QFileDialog::getOpenFileName(this, tr("Open File"), QString(),
+                                                          tr("Text Files (*.txt);;All Files (*)"));
+    if (filePath.isEmpty()) {
+        return;
+    }
+
+    if (loadFile(filePath)) {
+        statusBar()->showMessage(tr("Opened \"%1\"").arg(QFileInfo(filePath).fileName()), 2000);
+    }
+}
+
+void MainWindow::saveFile()
+{
+    if (m_currentFilePath.isEmpty()) {
+        saveFileAs();
+    } else if (writeFile(m_currentFilePath)) {
+        statusBar()->showMessage(tr("Saved"), 2000);
+    }
+}
+
+void MainWindow::saveFileAs()
+{
+    const QString filePath = QFileDialog::getSaveFileName(this, tr("Save File"), m_currentFilePath,
+                                                          tr("Text Files (*.txt);;All Files (*)"));
+    if (filePath.isEmpty()) {
+        return;
+    }
+
+    if (writeFile(filePath)) {
+        statusBar()->showMessage(tr("Saved \"%1\"").arg(QFileInfo(filePath).fileName()), 2000);
+    }
+}
+
+void MainWindow::updateWindowTitle()
+{
+    const QString fileName = m_currentFilePath.isEmpty()
+                                 ? tr("Untitled")
+                                 : QFileInfo(m_currentFilePath).fileName();
+    const QString modifiedMarker = ui->plainTextEdit->document()->isModified() ? QStringLiteral("*")
+                                                                               : QString();
+    setWindowTitle(tr("%1%2 - Notepad").arg(fileName, modifiedMarker));
+}
+
+bool MainWindow::maybeSave()
+{
+    if (!ui->plainTextEdit->document()->isModified()) {
+        return true;
+    }
+
+    const QMessageBox::StandardButton ret = QMessageBox::warning(
+        this,
+        tr("Unsaved Changes"),
+        tr("The document has been modified. Do you want to save your changes?"),
+        QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+
+    if (ret == QMessageBox::Save) {
+        saveFile();
+        return !ui->plainTextEdit->document()->isModified();
+    }
+
+    if (ret == QMessageBox::Cancel) {
+        return false;
+    }
+
+    return true;
+}
+
+bool MainWindow::loadFile(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Could not open file \"%1\": %2")
+                                 .arg(QFileInfo(filePath).fileName(), file.errorString()));
+        return false;
+    }
+
+    QTextStream in(&file);
+    in.setCodec("UTF-8");
+    ui->plainTextEdit->setPlainText(in.readAll());
+    ui->plainTextEdit->document()->setModified(false);
+    m_currentFilePath = filePath;
+    updateWindowTitle();
+    return true;
+}
+
+bool MainWindow::writeFile(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Could not write to file \"%1\": %2")
+                                 .arg(QFileInfo(filePath).fileName(), file.errorString()));
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+    out << ui->plainTextEdit->toPlainText();
+    file.close();
+
+    ui->plainTextEdit->document()->setModified(false);
+    m_currentFilePath = filePath;
+    updateWindowTitle();
+    return true;
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,6 +2,8 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QCloseEvent>
+#include <QString>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -17,7 +19,22 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
+private slots:
+    void newFile();
+    void openFile();
+    void saveFile();
+    void saveFileAs();
+    void updateWindowTitle();
+
 private:
     Ui::MainWindow *ui;
+    QString m_currentFilePath;
+
+    bool maybeSave();
+    bool loadFile(const QString &filePath);
+    bool writeFile(const QString &filePath);
 };
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -13,7 +13,17 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QPlainTextEdit" name="plainTextEdit">
+      <property name="tabStopDistance">
+       <double>80.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
@@ -23,8 +33,112 @@
      <height>22</height>
     </rect>
    </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionNew"/>
+    <addaction name="actionOpen"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionSave_As"/>
+    <addaction name="separator"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <widget class="QMenu" name="menuEdit">
+    <property name="title">
+     <string>Edit</string>
+    </property>
+    <addaction name="actionUndo"/>
+    <addaction name="actionRedo"/>
+    <addaction name="separator"/>
+    <addaction name="actionCut"/>
+    <addaction name="actionCopy"/>
+    <addaction name="actionPaste"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuEdit"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
+  <action name="actionNew">
+   <property name="text">
+    <string>New</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
+   </property>
+  </action>
+  <action name="actionOpen">
+   <property name="text">
+    <string>Open...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="text">
+    <string>Save</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionSave_As">
+   <property name="text">
+    <string>Save As...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
+  </action>
+  <action name="actionUndo">
+   <property name="text">
+    <string>Undo</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Z</string>
+   </property>
+  </action>
+  <action name="actionRedo">
+   <property name="text">
+    <string>Redo</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Y</string>
+   </property>
+  </action>
+  <action name="actionCut">
+   <property name="text">
+    <string>Cut</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+X</string>
+   </property>
+  </action>
+  <action name="actionCopy">
+   <property name="text">
+    <string>Copy</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+C</string>
+   </property>
+  </action>
+  <action name="actionPaste">
+   <property name="text">
+    <string>Paste</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+V</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
## Summary
- move window actions inside the QMainWindow element so the .ui structure matches Qt Designer expectations

## Testing
- not run (Qt tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e4a52676c8832e9d3c103c279739b5